### PR TITLE
Name internal

### DIFF
--- a/contracts/ModuleBase.sol
+++ b/contracts/ModuleBase.sol
@@ -9,7 +9,7 @@ import "./interfaces/IModuleBase.sol";
 abstract contract ModuleBase is IModuleBase, UUPSUpgradeable, ERC165 {
     IAccessControlDAO public accessControl;
     address public moduleFactory;
-    string private _name;
+    string internal _name;
 
     /// @notice Requires that a function caller has the associated role
     modifier authorized() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractal-framework/core-contracts",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractal-framework/core-contracts",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractal-framework/core-contracts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "files": [
     "contracts",
     "typechain-types"


### PR DESCRIPTION
This PR makes the _name variable internal instead of private so that it can be used by contracts that inherit from ModuleBase. It also updates the version of package.