### PR TITLE
Rename AccessControlDAO to DAOAccessControl

### DIFF
--- a/contracts/DAOAccessControl.sol
+++ b/contracts/DAOAccessControl.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import "./interfaces/IAccessControlDAO.sol";
+import "./interfaces/IDAOAccessControl.sol";
 
-/// @title Access Control
+/// @title DAO Access Control
 /// @notice Use this contract for managing DAO role based permissions
-contract AccessControlDAO is IAccessControlDAO, ERC165, UUPSUpgradeable {
+contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     string public constant DAO_ROLE = "DAO_ROLE";
     string public constant OPEN_ROLE = "OPEN_ROLE";
 
@@ -247,7 +247,7 @@ contract AccessControlDAO is IAccessControlDAO, ERC165, UUPSUpgradeable {
         returns (bool)
     {
         return
-            interfaceId == type(IAccessControlDAO).interfaceId ||
+            interfaceId == type(IDAOAccessControl).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import "./interfaces/IDAOFactory.sol";
-import "./interfaces/IAccessControlDAO.sol";
+import "./interfaces/IDAOAccessControl.sol";
 import "./interfaces/IDAO.sol";
 
 /// @notice A factory contract for deploying DAOs with an access control contract
@@ -48,7 +48,7 @@ contract DAOFactory is IDAOFactory, ERC165 {
             new ERC1967Proxy(
                 createDAOParams.accessControlImplementation,
                 abi.encodeWithSelector(
-                    IAccessControlDAO(payable(address(0))).initialize.selector,
+                    IDAOAccessControl(payable(address(0))).initialize.selector,
                     dao,
                     createDAOParams.roles,
                     createDAOParams.rolesAdmins,

--- a/contracts/ModuleBase.sol
+++ b/contracts/ModuleBase.sol
@@ -7,7 +7,7 @@ import "./interfaces/IModuleBase.sol";
 
 /// @notice An abstract contract to be inherited by module contracts
 abstract contract ModuleBase is IModuleBase, UUPSUpgradeable, ERC165 {
-    IAccessControlDAO public accessControl;
+    IDAOAccessControl public accessControl;
     address public moduleFactory;
     string internal _name;
 
@@ -33,7 +33,7 @@ abstract contract ModuleBase is IModuleBase, UUPSUpgradeable, ERC165 {
         internal
         onlyInitializing
     {
-        accessControl = IAccessControlDAO(_accessControl);
+        accessControl = IDAOAccessControl(_accessControl);
         moduleFactory = _moduleFactory;
         _name = __name;
         __UUPSUpgradeable_init();

--- a/contracts/interfaces/IDAOAccessControl.sol
+++ b/contracts/interfaces/IDAOAccessControl.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-interface IAccessControlDAO {
+interface IDAOAccessControl {
     struct RoleData {
         mapping(address => bool) members;
         string adminRole;

--- a/contracts/interfaces/IModuleBase.sol
+++ b/contracts/interfaces/IModuleBase.sol
@@ -1,13 +1,13 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "./IAccessControlDAO.sol";
+import "./IDAOAccessControl.sol";
 
 interface IModuleBase {
     error NotAuthorized();
 
-    /// @return IAccessControlDAO The Access control interface
-    function accessControl() external view returns (IAccessControlDAO);
+    /// @return IDAOAccessControl The Access control interface
+    function accessControl() external view returns (IDAOAccessControl);
 
     /// @notice Returns whether a given interface ID is supported
     /// @param interfaceId An interface ID bytes4 as defined by ERC-165

--- a/deploy/core/003_deploy_accessControl_implementation.ts
+++ b/deploy/core/003_deploy_accessControl_implementation.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { deployNonUpgradeable } from "../helpers/deployNonUpgradeable";
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
-  await deployNonUpgradeable(hre, "AccessControlDAO", []);
+  await deployNonUpgradeable(hre, "DAOAccessControl", []);
 };
 
 export default func;

--- a/test/AccessControl.test.ts
+++ b/test/AccessControl.test.ts
@@ -1,8 +1,8 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import {
-  AccessControlDAO,
-  AccessControlDAO__factory,
-  IAccessControlDAO__factory,
+  DAOAccessControl,
+  DAOAccessControl__factory,
+  IDAOAccessControl__factory,
 } from "../typechain-types";
 import chai from "chai";
 import { ethers } from "hardhat";
@@ -11,7 +11,7 @@ import getInterfaceSelector from "./helpers/getInterfaceSelector";
 const expect = chai.expect;
 
 describe("DAO Access Control Contract", function () {
-  let daoAccessControl: AccessControlDAO;
+  let daoAccessControl: DAOAccessControl;
 
   // Wallets
   let dao: SignerWithAddress;
@@ -51,7 +51,7 @@ describe("DAO Access Control Contract", function () {
     ] = await ethers.getSigners();
 
     // DAO Access Control contract deployment
-    daoAccessControl = await new AccessControlDAO__factory(deployer).deploy();
+    daoAccessControl = await new DAOAccessControl__factory(deployer).deploy();
   });
 
   describe("Initilize Access Control", function () {
@@ -77,7 +77,7 @@ describe("DAO Access Control Contract", function () {
       expect(
         await daoAccessControl.supportsInterface(
           // eslint-disable-next-line camelcase
-          getInterfaceSelector(IAccessControlDAO__factory.createInterface())
+          getInterfaceSelector(IDAOAccessControl__factory.createInterface())
         )
       ).to.eq(true);
 

--- a/test/DAO.test.ts
+++ b/test/DAO.test.ts
@@ -6,13 +6,13 @@ import {
   DAO__factory,
   DAO,
   IDAO__factory,
-  AccessControlDAO,
-  AccessControlDAO__factory,
+  DAOAccessControl,
+  DAOAccessControl__factory,
 } from "../typechain-types";
 import getInterfaceSelector from "./helpers/getInterfaceSelector";
 
 describe("DAO", () => {
-  let daoAccessControl: AccessControlDAO;
+  let daoAccessControl: DAOAccessControl;
   let dao: DAO;
   // Wallets
   let deployer: SignerWithAddress;
@@ -24,7 +24,7 @@ describe("DAO", () => {
     [deployer, executor1, executor2, executor3] = await ethers.getSigners();
 
     // Deploy Contracts
-    daoAccessControl = await new AccessControlDAO__factory(deployer).deploy();
+    daoAccessControl = await new DAOAccessControl__factory(deployer).deploy();
     dao = await new DAO__factory(deployer).deploy();
   });
 

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -1,8 +1,8 @@
 import { ethers, deployments } from "hardhat";
 import {
   DAO,
-  AccessControlDAO,
-  AccessControlDAO__factory,
+  DAOAccessControl,
+  DAOAccessControl__factory,
   DAOFactory,
   IDAOFactory__factory,
   DAO__factory,
@@ -20,12 +20,12 @@ describe("DAOFactory", () => {
   let upgrader1: SignerWithAddress;
   let daoFactory: DAOFactory;
   let daoImpl: DAO;
-  let accessControlImpl: AccessControlDAO;
+  let accessControlImpl: DAOAccessControl;
   let daoAddress: string;
   let accessControlAddress: string;
   let createDAOTx: ContractTransaction;
   let daoCreated: DAO;
-  let accessControlCreated: AccessControlDAO;
+  let accessControlCreated: DAOAccessControl;
 
   beforeEach(async () => {
     [deployer, executor1, executor2, executor3, upgrader1] =
@@ -36,7 +36,7 @@ describe("DAOFactory", () => {
     await deployments.fixture();
     daoFactory = await ethers.getContract("DAOFactory");
     daoImpl = await ethers.getContract("DAO");
-    accessControlImpl = await ethers.getContract("AccessControlDAO");
+    accessControlImpl = await ethers.getContract("DAOAccessControl");
 
     [daoAddress, accessControlAddress] = await daoFactory.callStatic.createDAO(
       deployer.address,
@@ -75,7 +75,7 @@ describe("DAOFactory", () => {
     daoCreated = DAO__factory.connect(daoAddress, deployer);
 
     // eslint-disable-next-line camelcase
-    accessControlCreated = AccessControlDAO__factory.connect(
+    accessControlCreated = DAOAccessControl__factory.connect(
       accessControlAddress,
       deployer
     );


### PR DESCRIPTION
This PR updates the AccessControlDAO contract and interface names to DAOAccessControl.

In a separate PR, I will update the package version and publish a new NPM package.