### PR TITLE
Remove dao factory address

### DIFF
--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -22,7 +22,7 @@ contract DAOFactory is IDAOFactory, ERC165 {
         dao = address(new ERC1967Proxy(createDAOParams.daoImplementation, ""));
         accessControl = createAccessControl(dao, createDAOParams);
 
-        IDAO(dao).initialize(accessControl, createDAOParams.daoFactory, createDAOParams.daoName);
+        IDAO(dao).initialize(accessControl, address(this), createDAOParams.daoName);
 
         emit DAOCreated(dao, accessControl, msg.sender, creator);
     }

--- a/contracts/interfaces/IDAOFactory.sol
+++ b/contracts/interfaces/IDAOFactory.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 interface IDAOFactory {
     struct CreateDAOParams {
         address daoImplementation;
-        address daoFactory;
         address accessControlImplementation;
         string daoName;
         string[] roles;

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -42,7 +42,6 @@ describe("DAOFactory", () => {
       deployer.address,
       {
         daoImplementation: daoImpl.address,
-        daoFactory: daoFactory.address,
         accessControlImplementation: accessControlImpl.address,
         daoName: "TestDao",
         roles: ["EXECUTE_ROLE", "UPGRADE_ROLE"],
@@ -58,7 +57,6 @@ describe("DAOFactory", () => {
 
     createDAOTx = await daoFactory.createDAO(deployer.address, {
       daoImplementation: daoImpl.address,
-      daoFactory: daoFactory.address,
       accessControlImplementation: accessControlImpl.address,
       daoName: "TestDao",
       roles: ["EXECUTE_ROLE", "UPGRADE_ROLE"],


### PR DESCRIPTION
The DAO factory address had been added to the CreateDAOParams that get passed to the DAOFactory.
This address is not necessary as a param since the factory can just use address(this)
This PR removes the DAOFactory address from the CreateDAOParams.