### PR TITLE
Rename module factory base

### DIFF
--- a/contracts/DAO.sol
+++ b/contracts/DAO.sol
@@ -10,10 +10,10 @@ import "./ModuleBase.sol";
 contract DAO is IDAO, ModuleBase {
     /// @notice Function for initializing the contract that can only be called once
     /// @param _accessControl The address of the access control contract
-    /// @param _moduleFactoryBase The address of the module factory
+    /// @param _moduleFactory The address of the module factory
     /// @param _name Name of the Dao
-    function initialize(address _accessControl, address _moduleFactoryBase, string calldata _name) external initializer {
-        __initBase(_accessControl, _moduleFactoryBase, _name);
+    function initialize(address _accessControl, address _moduleFactory, string calldata _name) external initializer {
+        __initBase(_accessControl, _moduleFactory, _name);
     }
 
     /// @notice A function for executing function calls from the DAO

--- a/contracts/interfaces/IDAO.sol
+++ b/contracts/interfaces/IDAO.sol
@@ -11,9 +11,9 @@ interface IDAO {
 
     /// @notice Function for initializing the Dao
     /// @param _accessControl The address of the access control contract
-    /// @param _moduleFactoryBase The address of the module factory
+    /// @param _moduleFactory The address of the module factory
     /// @param _name Name of the Dao
-    function initialize(address _accessControl, address _moduleFactoryBase, string calldata _name) external;
+    function initialize(address _accessControl, address _moduleFactory, string calldata _name) external;
 
     /// @notice A function for executing function calls from the DAO
     /// @param targets An array of addresses to target for the function calls


### PR DESCRIPTION
In the DAO and IDAO contracts, the parameter moduleFactoryBase is used. However, ModuleFactoryBase is an abstract contract, and the contract being dealt with is the actual ModuleFactory.

This PR renames these moduleFactoryBase parameters to moduleFactory.