### PR TITLE
Create2 Pattern for MVD

### DIFF
--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -16,7 +16,7 @@ contract DAOFactory is IDAOFactory, ERC165 {
     /// @param createDAOParams Struct of all the parameters required to create a DAO
     /// @return dao The address of the deployed DAO proxy contract
     /// @return accessControl The address of the deployed access control proxy contract
-    function createDAO(
+    function createMVD(
         address creator,
         CreateDAOParams calldata createDAOParams
     ) external returns (address dao, address accessControl) {

--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -16,7 +16,7 @@ contract DAOFactory is IDAOFactory, ERC165 {
     /// @param createDAOParams Struct of all the parameters required to create a DAO
     /// @return dao The address of the deployed DAO proxy contract
     /// @return accessControl The address of the deployed access control proxy contract
-    function createMVD(
+    function createDAO(
         address creator,
         CreateDAOParams calldata createDAOParams
     ) external returns (address dao, address accessControl) {

--- a/contracts/interfaces/IDAOFactory.sol
+++ b/contracts/interfaces/IDAOFactory.sol
@@ -5,6 +5,7 @@ interface IDAOFactory {
     struct CreateDAOParams {
         address daoImplementation;
         address accessControlImplementation;
+        bytes32 salt;
         string daoName;
         string[] roles;
         string[] rolesAdmins;

--- a/contracts/interfaces/IDAOFactory.sol
+++ b/contracts/interfaces/IDAOFactory.sol
@@ -21,7 +21,7 @@ interface IDAOFactory {
     /// @param createDAOParams Struct of all the parameters required to create a DAO
     /// @return dao The address of the deployed DAO proxy contract
     /// @return accessControl The address of the deployed access control proxy contract
-    function createMVD(address creator, CreateDAOParams calldata createDAOParams)
+    function createDAO(address creator, CreateDAOParams calldata createDAOParams)
         external
         returns (address, address);
 }

--- a/contracts/interfaces/IDAOFactory.sol
+++ b/contracts/interfaces/IDAOFactory.sol
@@ -21,7 +21,7 @@ interface IDAOFactory {
     /// @param createDAOParams Struct of all the parameters required to create a DAO
     /// @return dao The address of the deployed DAO proxy contract
     /// @return accessControl The address of the deployed access control proxy contract
-    function createDAO(address creator, CreateDAOParams calldata createDAOParams)
+    function createMVD(address creator, CreateDAOParams calldata createDAOParams)
         external
         returns (address, address);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractal-framework/core-contracts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "files": [
     "dist",
     "contracts"

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -13,7 +13,7 @@ import { ContractTransaction } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import getInterfaceSelector from "./helpers/getInterfaceSelector";
 
-describe.only("DAOFactory", () => {
+describe("DAOFactory", () => {
   let deployer: SignerWithAddress;
   let executor1: SignerWithAddress;
   let executor2: SignerWithAddress;

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -12,7 +12,7 @@ import { ContractTransaction } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import getInterfaceSelector from "./helpers/getInterfaceSelector";
 
-describe("DAOFactory", () => {
+describe.only("DAOFactory", () => {
   let deployer: SignerWithAddress;
   let executor1: SignerWithAddress;
   let executor2: SignerWithAddress;
@@ -43,6 +43,7 @@ describe("DAOFactory", () => {
       {
         daoImplementation: daoImpl.address,
         accessControlImplementation: accessControlImpl.address,
+        salt: ethers.utils.formatBytes32String("hi"),
         daoName: "TestDao",
         roles: ["EXECUTE_ROLE", "UPGRADE_ROLE"],
         rolesAdmins: ["DAO_ROLE", "DAO_ROLE"],
@@ -58,6 +59,7 @@ describe("DAOFactory", () => {
     createDAOTx = await daoFactory.createDAO(deployer.address, {
       daoImplementation: daoImpl.address,
       accessControlImplementation: accessControlImpl.address,
+      salt: ethers.utils.formatBytes32String("hi"),
       daoName: "TestDao",
       roles: ["EXECUTE_ROLE", "UPGRADE_ROLE"],
       rolesAdmins: ["DAO_ROLE", "DAO_ROLE"],

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -38,7 +38,7 @@ describe.only("DAOFactory", () => {
     daoImpl = await ethers.getContract("DAO");
     accessControlImpl = await ethers.getContract("DAOAccessControl");
 
-    [daoAddress, accessControlAddress] = await daoFactory.callStatic.createDAO(
+    [daoAddress, accessControlAddress] = await daoFactory.callStatic.createMVD(
       deployer.address,
       {
         daoImplementation: daoImpl.address,
@@ -56,7 +56,7 @@ describe.only("DAOFactory", () => {
       }
     );
 
-    createDAOTx = await daoFactory.createDAO(deployer.address, {
+    createDAOTx = await daoFactory.createMVD(deployer.address, {
       daoImplementation: daoImpl.address,
       accessControlImplementation: accessControlImpl.address,
       salt: ethers.utils.formatBytes32String("hi"),

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -39,7 +39,7 @@ describe("DAOFactory", () => {
     daoImpl = await ethers.getContract("DAO");
     accessControlImpl = await ethers.getContract("DAOAccessControl");
 
-    [daoAddress, accessControlAddress] = await daoFactory.callStatic.createMVD(
+    [daoAddress, accessControlAddress] = await daoFactory.callStatic.createDAO(
       deployer.address,
       {
         daoImplementation: daoImpl.address,
@@ -57,7 +57,7 @@ describe("DAOFactory", () => {
       }
     );
 
-    createDAOTx = await daoFactory.createMVD(deployer.address, {
+    createDAOTx = await daoFactory.createDAO(deployer.address, {
       daoImplementation: daoImpl.address,
       accessControlImplementation: accessControlImpl.address,
       salt: ethers.utils.formatBytes32String("hi"),


### PR DESCRIPTION
- Created the Create2 pattern for MVD. 
- Important to note is the now passing of a arb salt value into the createMVD method.
- Utilize tx.orgin, chainId, and arb salt to determine the address location.
- another thing to note is the use of ERC1967.creation code and additional init function for clean contract creation.
- Tests check if address can be predicted.