### PR TITLE
Acl cleanup

### DIFF
--- a/contracts/DAOAccessControl.sol
+++ b/contracts/DAOAccessControl.sol
@@ -56,7 +56,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     /// @param roles The roles being granted
     /// @param roleAdmins The roles being granted as admins of the specified of roles
     /// @param members Addresses being granted each specified role
-    function grantRolesAndAdmins(
+    function daoGrantRolesAndAdmins(
         string[] memory roles,
         string[] memory roleAdmins,
         address[][] memory members
@@ -67,49 +67,18 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     /// @notice Grants roles to the specified addresses
     /// @param roles The roles being granted
     /// @param members Addresses being granted each specified role
-    function grantRoles(string[] memory roles, address[][] memory members)
+    function daoGrantRoles(string[] memory roles, address[][] memory members)
         external
         onlyRole(DAO_ROLE)
     {
         _grantRoles(roles, members);
     }
 
-    /// @notice Grants a role to the specified address
-    /// @param role The role being granted
-    /// @param account The address being granted the specified role
-    function grantRole(string memory role, address account)
-        external
-        onlyRole(getRoleAdmin(role))
-    {
-        _grantRole(role, account);
-    }
-
-    /// @notice Revokes a role from the specified address
-    /// @param role The role being revoked
-    /// @param account The address the role is being revoked from
-    function revokeRole(string memory role, address account)
-        external
-        onlyRole(getRoleAdmin(role))
-    {
-        _revokeRole(role, account);
-    }
-
-    /// @notice Enables an address to remove one of its own roles
-    /// @param role The role being renounced
-    /// @param account The address renouncing the role
-    function renounceRole(string memory role, address account) external {
-        if (account != msg.sender) {
-            revert OnlySelfRenounce();
-        }
-
-        _revokeRole(role, account);
-    }
-
     /// @notice Authorizes roles to execute the specified actions
     /// @param targets The contract addresses that the action functions are implemented on
     /// @param functionDescs The function descriptions used to define the actions
     /// @param roles Roles being granted permission for an action
-    function addActionsRoles(
+    function daoAddActionsRoles(
         address[] memory targets,
         string[] memory functionDescs,
         string[][] memory roles
@@ -121,7 +90,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     /// @param targets The contract addresses that the action functions are implemented on
     /// @param functionDescs The function description used to define the actions
     /// @param roles Roles that action permissions are being removed on
-    function removeActionsRoles(
+    function daoRemoveActionsRoles(
         address[] memory targets,
         string[] memory functionDescs,
         string[][] memory roles
@@ -143,6 +112,37 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
             }
         }
     }
+
+    /// @notice Grants a role to the specified address
+    /// @param role The role being granted
+    /// @param account The address being granted the specified role
+    function adminGrantRole(string memory role, address account)
+        external
+        onlyRole(getRoleAdmin(role))
+    {
+        _grantRole(role, account);
+    }
+
+    /// @notice Revokes a role from the specified address
+    /// @param role The role being revoked
+    /// @param account The address the role is being revoked from
+    function adminRevokeRole(string memory role, address account)
+        external
+        onlyRole(getRoleAdmin(role))
+    {
+        _revokeRole(role, account);
+    }
+
+    /// @notice Enables an address to remove one of its own roles
+    /// @param role The role being renounced
+    /// @param account The address renouncing the role
+    function userRenounceRole(string memory role, address account) external {
+        if (account != msg.sender) {
+            revert OnlySelfRenounce();
+        }
+
+        _revokeRole(role, account);
+    }  
 
     /// @notice Checks if a caller has the permissions to execute the specific action
     /// @param caller Address attempting to execute the action

--- a/contracts/DAOAccessControl.sol
+++ b/contracts/DAOAccessControl.sol
@@ -53,6 +53,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     }
 
     /// @notice Grants roles to the specified addresses and defines admin roles
+    /// @notice This function can only be called by the DAO
     /// @param roles The roles being granted
     /// @param roleAdmins The roles being granted as admins of the specified of roles
     /// @param members Addresses being granted each specified role
@@ -65,6 +66,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     }
 
     /// @notice Grants roles to the specified addresses
+    /// @notice This function can only be called by the DAO
     /// @param roles The roles being granted
     /// @param members Addresses being granted each specified role
     function daoGrantRoles(string[] memory roles, address[][] memory members)
@@ -75,6 +77,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     }
 
     /// @notice Authorizes roles to execute the specified actions
+    /// @notice This function can only be called by the DAO
     /// @param targets The contract addresses that the action functions are implemented on
     /// @param functionDescs The function descriptions used to define the actions
     /// @param roles Roles being granted permission for an action
@@ -87,6 +90,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     }
 
     /// @notice Removes autorization for roles to execute the specified actions
+    /// @notice This function can only be called by the DAO
     /// @param targets The contract addresses that the action functions are implemented on
     /// @param functionDescs The function description used to define the actions
     /// @param roles Roles that action permissions are being removed on
@@ -114,6 +118,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     }
 
     /// @notice Grants a role to the specified address
+    /// @notice This function can only be called by an admin of the specified role
     /// @param role The role being granted
     /// @param account The address being granted the specified role
     function adminGrantRole(string memory role, address account)
@@ -124,6 +129,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     }
 
     /// @notice Revokes a role from the specified address
+    /// @notice This function can only be called by an admin of the specified role
     /// @param role The role being revoked
     /// @param account The address the role is being revoked from
     function adminRevokeRole(string memory role, address account)
@@ -134,6 +140,7 @@ contract DAOAccessControl is IDAOAccessControl, ERC165, UUPSUpgradeable {
     }
 
     /// @notice Enables an address to remove one of its own roles
+    /// @notice This function can only be called by the account specified
     /// @param role The role being renounced
     /// @param account The address renouncing the role
     function userRenounceRole(string memory role, address account) external {

--- a/contracts/interfaces/IDAOAccessControl.sol
+++ b/contracts/interfaces/IDAOAccessControl.sol
@@ -50,6 +50,7 @@ interface IDAOAccessControl {
     ) external;
 
     /// @notice Grants roles to the specified addresses and defines admin roles
+    /// @notice This function can only be called by the DAO
     /// @param roles The roles being granted
     /// @param roleAdmins The roles being granted as admins of the specified of roles
     /// @param members Addresses being granted each specified role
@@ -60,12 +61,14 @@ interface IDAOAccessControl {
     ) external;
 
     /// @notice Grants roles to the specified addresses
+    /// @notice This function can only be called by the DAO
     /// @param roles The roles being granted
     /// @param members Addresses being granted each specified role
     function daoGrantRoles(string[] memory roles, address[][] memory members)
         external;
 
     /// @notice Authorizes roles to execute the specified actions
+    /// @notice This function can only be called by the DAO
     /// @param targets The contract addresses that the action functions are implemented on
     /// @param functionDescs The function descriptions used to define the actions
     /// @param roles Roles being granted permission for an action
@@ -76,6 +79,7 @@ interface IDAOAccessControl {
     ) external;
 
     /// @notice Removes autorization for roles to execute the specified actions
+    /// @notice This function can only be called by the DAO
     /// @param targets The contract addresses that the action functions are implemented on
     /// @param functionDescs The function description used to define the actions
     /// @param roles Roles that action permissions are being removed on
@@ -86,18 +90,21 @@ interface IDAOAccessControl {
     ) external;
 
     /// @notice Grants a role to the specified address
+    /// @notice This function can only be called by an admin of the specified role
     /// @param role The role being granted
     /// @param account The address being granted the specified role
     function adminGrantRole(string memory role, address account)
         external;
 
     /// @notice Revokes a role from the specified address
+    /// @notice This function can only be called by an admin of the specified role
     /// @param role The role being revoked
     /// @param account The address the role is being revoked from
     function adminRevokeRole(string memory role, address account)
         external;
 
     /// @notice Enables an address to remove one of its own roles
+    /// @notice This function can only be called by the account specified
     /// @param role The role being renounced
     /// @param account The address renouncing the role
     function userRenounceRole(string memory role, address account) external;

--- a/contracts/interfaces/IDAOAccessControl.sol
+++ b/contracts/interfaces/IDAOAccessControl.sol
@@ -53,7 +53,7 @@ interface IDAOAccessControl {
     /// @param roles The roles being granted
     /// @param roleAdmins The roles being granted as admins of the specified of roles
     /// @param members Addresses being granted each specified role
-    function grantRolesAndAdmins(
+    function daoGrantRolesAndAdmins(
         string[] memory roles,
         string[] memory roleAdmins,
         address[][] memory members
@@ -62,29 +62,14 @@ interface IDAOAccessControl {
     /// @notice Grants roles to the specified addresses
     /// @param roles The roles being granted
     /// @param members Addresses being granted each specified role
-    function grantRoles(string[] memory roles, address[][] memory members)
+    function daoGrantRoles(string[] memory roles, address[][] memory members)
         external;
-
-    /// @notice Grants a role to the specified address
-    /// @param role The role being granted
-    /// @param account The address being granted the specified role
-    function grantRole(string memory role, address account) external;
-
-    /// @notice Revokes a role from the specified address
-    /// @param role The role being revoked
-    /// @param account The address the role is being revoked from
-    function revokeRole(string memory role, address account) external;
-
-    /// @notice Enables an address to remove one of its own roles
-    /// @param role The role being renounced
-    /// @param account The address renouncing the role
-    function renounceRole(string memory role, address account) external;
 
     /// @notice Authorizes roles to execute the specified actions
     /// @param targets The contract addresses that the action functions are implemented on
     /// @param functionDescs The function descriptions used to define the actions
     /// @param roles Roles being granted permission for an action
-    function addActionsRoles(
+    function daoAddActionsRoles(
         address[] memory targets,
         string[] memory functionDescs,
         string[][] memory roles
@@ -94,11 +79,28 @@ interface IDAOAccessControl {
     /// @param targets The contract addresses that the action functions are implemented on
     /// @param functionDescs The function description used to define the actions
     /// @param roles Roles that action permissions are being removed on
-    function removeActionsRoles(
+    function daoRemoveActionsRoles(
         address[] memory targets,
         string[] memory functionDescs,
         string[][] memory roles
     ) external;
+
+    /// @notice Grants a role to the specified address
+    /// @param role The role being granted
+    /// @param account The address being granted the specified role
+    function adminGrantRole(string memory role, address account)
+        external;
+
+    /// @notice Revokes a role from the specified address
+    /// @param role The role being revoked
+    /// @param account The address the role is being revoked from
+    function adminRevokeRole(string memory role, address account)
+        external;
+
+    /// @notice Enables an address to remove one of its own roles
+    /// @param role The role being renounced
+    /// @param account The address renouncing the role
+    function userRenounceRole(string memory role, address account) external;
 
     /// @notice Checks if a caller has the permissions to execute the specific action
     /// @param caller Address attempting to execute the action

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractal-framework/core-contracts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractal-framework/core-contracts",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractal-framework/core-contracts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "files": [
     "dist",
     "contracts"

--- a/test/AccessControl.test.ts
+++ b/test/AccessControl.test.ts
@@ -162,7 +162,7 @@ describe("DAO Access Control Contract", function () {
     });
 
     it("Admin of a role can grant new members", async () => {
-      await daoAccessControl.connect(dao).grantRolesAndAdmins(
+      await daoAccessControl.connect(dao).daoGrantRolesAndAdmins(
         [roleBString, roleAString],
         [roleAString, daoRoleString],
         [
@@ -181,11 +181,11 @@ describe("DAO Access Control Contract", function () {
 
       await daoAccessControl
         .connect(roleAMember1)
-        .grantRole(roleBString, user1.address);
+        .adminGrantRole(roleBString, user1.address);
 
       await daoAccessControl
         .connect(roleAMember1)
-        .grantRole(roleBString, user2.address);
+        .adminGrantRole(roleBString, user2.address);
 
       expect(await daoAccessControl.hasRole(roleBString, user1.address)).to.eq(
         true
@@ -197,7 +197,7 @@ describe("DAO Access Control Contract", function () {
     });
 
     it("Non-Admin of a role can not grant new members", async () => {
-      await daoAccessControl.connect(dao).grantRolesAndAdmins(
+      await daoAccessControl.connect(dao).daoGrantRolesAndAdmins(
         [roleBString, roleAString],
         [roleAString, daoRoleString],
         [
@@ -215,20 +215,20 @@ describe("DAO Access Control Contract", function () {
       );
 
       await expect(
-        daoAccessControl.connect(user1).grantRole(roleBString, user1.address)
+        daoAccessControl.connect(user1).adminGrantRole(roleBString, user1.address)
       ).to.be.revertedWith(`MissingRole("${user1.address}", "${roleAString}")`);
 
       await expect(
         daoAccessControl
           .connect(roleBMember1)
-          .grantRole(roleBString, user1.address)
+          .adminGrantRole(roleBString, user1.address)
       ).to.be.revertedWith(
         `MissingRole("${roleBMember1.address}", "${roleAString}")`
       );
     });
 
     it("Admin of a role can revoke members", async () => {
-      await daoAccessControl.connect(dao).grantRolesAndAdmins(
+      await daoAccessControl.connect(dao).daoGrantRolesAndAdmins(
         [roleBString, roleAString],
         [roleAString, daoRoleString],
         [
@@ -247,11 +247,11 @@ describe("DAO Access Control Contract", function () {
 
       await daoAccessControl
         .connect(roleAMember1)
-        .revokeRole(roleBString, roleBMember1.address);
+        .adminRevokeRole(roleBString, roleBMember1.address);
 
       await daoAccessControl
         .connect(roleAMember1)
-        .revokeRole(roleBString, roleBMember2.address);
+        .adminRevokeRole(roleBString, roleBMember2.address);
 
       expect(
         await daoAccessControl.hasRole(roleBString, roleBMember1.address)
@@ -263,7 +263,7 @@ describe("DAO Access Control Contract", function () {
     });
 
     it("Non-Admin of a role can not revoke members", async () => {
-      await daoAccessControl.connect(dao).grantRolesAndAdmins(
+      await daoAccessControl.connect(dao).daoGrantRolesAndAdmins(
         [roleBString, roleAString],
         [roleAString, daoRoleString],
         [
@@ -275,7 +275,7 @@ describe("DAO Access Control Contract", function () {
       await expect(
         daoAccessControl
           .connect(roleBMember1)
-          .revokeRole(roleBString, roleBMember2.address)
+          .adminRevokeRole(roleBString, roleBMember2.address)
       ).to.be.revertedWith(
         `MissingRole("${roleBMember1.address}", "${roleAString}")`
       );
@@ -283,12 +283,12 @@ describe("DAO Access Control Contract", function () {
       await expect(
         daoAccessControl
           .connect(user1)
-          .revokeRole(roleBString, roleBMember2.address)
+          .adminRevokeRole(roleBString, roleBMember2.address)
       ).to.be.revertedWith(`MissingRole("${user1.address}", "${roleAString}")`);
     });
 
     it("A role member can renounce their role", async () => {
-      await daoAccessControl.connect(dao).grantRolesAndAdmins(
+      await daoAccessControl.connect(dao).daoGrantRolesAndAdmins(
         [roleBString, roleAString],
         [roleAString, daoRoleString],
         [
@@ -307,11 +307,11 @@ describe("DAO Access Control Contract", function () {
 
       await daoAccessControl
         .connect(roleBMember1)
-        .renounceRole(roleBString, roleBMember1.address);
+        .userRenounceRole(roleBString, roleBMember1.address);
 
       await daoAccessControl
         .connect(roleBMember2)
-        .renounceRole(roleBString, roleBMember2.address);
+        .userRenounceRole(roleBString, roleBMember2.address);
 
       expect(
         await daoAccessControl.hasRole(roleBString, roleBMember1.address)
@@ -323,7 +323,7 @@ describe("DAO Access Control Contract", function () {
     });
 
     it("A role member cannot renounce another user's role", async () => {
-      await daoAccessControl.connect(dao).grantRolesAndAdmins(
+      await daoAccessControl.connect(dao).daoGrantRolesAndAdmins(
         [roleBString, roleAString],
         [roleAString, daoRoleString],
         [
@@ -335,18 +335,18 @@ describe("DAO Access Control Contract", function () {
       await expect(
         daoAccessControl
           .connect(roleAMember1)
-          .renounceRole(roleBString, roleBMember1.address)
+          .userRenounceRole(roleBString, roleBMember1.address)
       ).to.be.revertedWith("OnlySelfRenounce()");
 
       await expect(
         daoAccessControl
           .connect(roleBMember2)
-          .renounceRole(roleBString, roleBMember1.address)
+          .userRenounceRole(roleBString, roleBMember1.address)
       ).to.be.revertedWith("OnlySelfRenounce()");
     });
 
     it("Should batch create Roles", async () => {
-      await daoAccessControl.connect(dao).grantRolesAndAdmins(
+      await daoAccessControl.connect(dao).daoGrantRolesAndAdmins(
         [roleBString, roleAString],
         [roleAString, daoRoleString],
         [
@@ -377,7 +377,7 @@ describe("DAO Access Control Contract", function () {
     });
 
     it("Should override/update Role Admins", async () => {
-      await daoAccessControl.connect(dao).grantRolesAndAdmins(
+      await daoAccessControl.connect(dao).daoGrantRolesAndAdmins(
         [roleBString, roleAString],
         [roleAString, daoRoleString],
         [
@@ -388,7 +388,7 @@ describe("DAO Access Control Contract", function () {
 
       await daoAccessControl
         .connect(dao)
-        .grantRolesAndAdmins(
+        .daoGrantRolesAndAdmins(
           [roleAString, roleBString],
           [roleBString, daoRoleString],
           [[], []]
@@ -416,7 +416,7 @@ describe("DAO Access Control Contract", function () {
 
     it("Should revert UnAuthorized (batch create)", async () => {
       await expect(
-        daoAccessControl.connect(executor1).grantRolesAndAdmins(
+        daoAccessControl.connect(executor1).daoGrantRolesAndAdmins(
           [roleBString, roleAString],
           [roleAString, daoRoleString],
           [
@@ -449,7 +449,7 @@ describe("DAO Access Control Contract", function () {
       // Give roleA authorization over action2
       await daoAccessControl
         .connect(dao)
-        .addActionsRoles(
+        .daoAddActionsRoles(
           [deployer.address, deployer.address],
           [function1, function2],
           [[roleAString, roleBString], [roleAString]]
@@ -469,7 +469,7 @@ describe("DAO Access Control Contract", function () {
       await expect(
         daoAccessControl
           .connect(executor1)
-          .addActionsRoles(
+          .daoAddActionsRoles(
             [deployer.address, deployer.address],
             [function1, function2],
             [[roleAString, roleBString], [roleAString]]
@@ -482,7 +482,7 @@ describe("DAO Access Control Contract", function () {
       // Give roleA authorization over action2
       await daoAccessControl
         .connect(dao)
-        .addActionsRoles(
+        .daoAddActionsRoles(
           [deployer.address, deployer.address],
           [function1, function2],
           [[roleAString, roleBString], [roleAString]]
@@ -505,7 +505,7 @@ describe("DAO Access Control Contract", function () {
 
       await daoAccessControl
         .connect(dao)
-        .removeActionsRoles(
+        .daoRemoveActionsRoles(
           [deployer.address, deployer.address],
           [function1, function2],
           [[roleAString], [roleAString]]
@@ -536,7 +536,7 @@ describe("DAO Access Control Contract", function () {
       // Give roleA authorization over action2
       await daoAccessControl
         .connect(dao)
-        .addActionsRoles(
+        .daoAddActionsRoles(
           [deployer.address, deployer.address],
           [function1, function2],
           [[roleAString, roleBString], [roleAString]]
@@ -546,7 +546,7 @@ describe("DAO Access Control Contract", function () {
       await expect(
         daoAccessControl
           .connect(executor1)
-          .removeActionsRoles(
+          .daoRemoveActionsRoles(
             [deployer.address, deployer.address],
             [function1, function2],
             [[roleAString, roleBString], [roleAString]]

--- a/test/DAO.test.ts
+++ b/test/DAO.test.ts
@@ -63,13 +63,13 @@ describe("DAO", () => {
 
     it("doesn't allow anyone to grant the EXECUTE role", async () => {
       await expect(
-        daoAccessControl.grantRole("EXECUTE_ROLE", deployer.address)
+        daoAccessControl.adminGrantRole("EXECUTE_ROLE", deployer.address)
       ).to.be.revertedWith(`MissingRole("${deployer.address}", "")`);
     });
 
     it("doesn't allow anyone to revoke existing roles", async () => {
       await expect(
-        daoAccessControl.revokeRole("EXECUTE_ROLE", executor1.address)
+        daoAccessControl.adminRevokeRole("EXECUTE_ROLE", executor1.address)
       ).to.be.revertedWith(`MissingRole("${deployer.address}", "")`);
     });
 
@@ -110,7 +110,7 @@ describe("DAO", () => {
 
     it("executor EOA should be able to call `execute`", async () => {
       const transferCallData = daoAccessControl.interface.encodeFunctionData(
-        "grantRole",
+        "adminGrantRole",
         ["EXECUTE_ROLE", executor3.address]
       );
 
@@ -137,7 +137,7 @@ describe("DAO", () => {
 
     it("UnAuthUser should NOT be able to call `execute`", async () => {
       const transferCallData = daoAccessControl.interface.encodeFunctionData(
-        "grantRole",
+        "adminGrantRole",
         ["EXECUTE_ROLE", executor3.address]
       );
 
@@ -156,7 +156,7 @@ describe("DAO", () => {
         "BadDao"
       );
       const transferCallData = daoAccessControl.interface.encodeFunctionData(
-        "grantRole",
+        "adminGrantRole",
         ["EXECUTE_ROLE", executor3.address]
       );
 

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -202,7 +202,7 @@ describe("DAOFactory", () => {
 
   it("executor EOA should be able to call `execute`", async () => {
     const transferCallData = accessControlCreated.interface.encodeFunctionData(
-      "grantRole",
+      "adminGrantRole",
       ["EXECUTE_ROLE", executor3.address]
     );
 
@@ -229,7 +229,7 @@ describe("DAOFactory", () => {
 
   it("Non executor EOA should revert w/ Execute", async () => {
     const transferCallData = accessControlCreated.interface.encodeFunctionData(
-      "grantRole",
+      "adminGrantRole",
       ["EXECUTE_ROLE", executor3.address]
     );
 


### PR DESCRIPTION
This PR updates the function naming convention within the Access Control contract, and updates the tests accordingly. The new naming is as followings:
 - Function names prefaced with "dao" can only be called by the DAO
 - Function names prefaced with "admin" can only be called by the admin of the affected role
 - Function names prefaced with "user" can only be called by a user that holds the affected role