### PR TITLE
Refactor salt

### DIFF
--- a/contracts/DAO.sol
+++ b/contracts/DAO.sol
@@ -43,18 +43,4 @@ contract DAO is IDAO, ModuleBase {
         }
         emit Executed(targets, values, calldatas);
     }
-
-    /// @notice Returns whether a given interface ID is supported
-    /// @param interfaceId An interface ID bytes4 as defined by ERC-165
-    /// @return bool Indicates whether the interface is supported
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        override
-        returns (bool)
-    {
-        return
-            interfaceId == type(IDAO).interfaceId ||
-            super.supportsInterface(interfaceId);
-    }
 }

--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -91,19 +91,4 @@ contract DAOFactory is IDAOFactory, ERC165Storage {
             )
         );
     }
-
-    /// @notice Returns whether a given interface ID is supported
-    /// @param interfaceId An interface ID bytes4 as defined by ERC-165
-    /// @return bool Indicates whether the interface is supported
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        return
-            interfaceId == type(IDAOFactory).interfaceId ||
-            super.supportsInterface(interfaceId);
-    }
 }

--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -25,7 +25,7 @@ contract DAOFactory is IDAOFactory, ERC165Storage {
         CreateDAOParams calldata createDAOParams
     ) external returns (address dao, address accessControl) {
         dao = _createDAO(creator, createDAOParams);
-        accessControl = _createAccessControl(createDAOParams);
+        accessControl = _createAccessControl(creator, createDAOParams);
 
         address[] memory targets = new address[](
             createDAOParams.daoFunctionDescs.length

--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -71,7 +71,7 @@ contract DAOFactory is IDAOFactory, ERC165Storage {
     }
 
     function _createAccessControl(CreateDAOParams memory createDAOParams)
-        private
+        internal
         returns (address _accessControl)
     {
         _accessControl = Create2.deploy(

--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -56,6 +56,10 @@ contract DAOFactory is IDAOFactory, ERC165Storage {
         emit DAOCreated(dao, accessControl, msg.sender, creator);
     }
 
+    /// @notice Creates a DAO contract
+    /// @param creator Address of the Dao Creator
+    /// @param createDAOParams Struct of all the parameters required to create a DAO
+    /// @return _dao The address of the deployed DAO proxy contract
     function _createDAO(address creator, CreateDAOParams calldata createDAOParams)
         internal
         returns (address _dao)
@@ -70,13 +74,17 @@ contract DAOFactory is IDAOFactory, ERC165Storage {
         );
     }
 
-    function _createAccessControl(CreateDAOParams memory createDAOParams)
+    /// @notice Creates a an access control contract
+    /// @param creator Address of the Dao Creator
+    /// @param createDAOParams Struct of all the parameters required to create a DAO
+    /// @return _accessControl The address of the deployed access control proxy contract
+    function _createAccessControl(address creator, CreateDAOParams memory createDAOParams)
         internal
         returns (address _accessControl)
     {
         _accessControl = Create2.deploy(
             0,
-            keccak256(abi.encodePacked(tx.origin, block.chainid, createDAOParams.salt)),
+            keccak256(abi.encodePacked(creator, msg.sender, block.chainid, createDAOParams.salt)),
             abi.encodePacked(
                 type(ERC1967Proxy).creationCode,
                 abi.encode(createDAOParams.accessControlImplementation, "")

--- a/contracts/DAOFactory.sol
+++ b/contracts/DAOFactory.sol
@@ -24,7 +24,7 @@ contract DAOFactory is IDAOFactory, ERC165Storage {
         address creator,
         CreateDAOParams calldata createDAOParams
     ) external returns (address dao, address accessControl) {
-        dao = _createDAO(createDAOParams);
+        dao = _createDAO(creator, createDAOParams);
         accessControl = _createAccessControl(createDAOParams);
 
         address[] memory targets = new address[](
@@ -56,13 +56,13 @@ contract DAOFactory is IDAOFactory, ERC165Storage {
         emit DAOCreated(dao, accessControl, msg.sender, creator);
     }
 
-    function _createDAO(CreateDAOParams calldata createDAOParams)
+    function _createDAO(address creator, CreateDAOParams calldata createDAOParams)
         internal
         returns (address _dao)
     {
         _dao = Create2.deploy(
             0,
-            keccak256(abi.encodePacked(tx.origin, block.chainid, createDAOParams.salt)),
+            keccak256(abi.encodePacked(creator, msg.sender, block.chainid, createDAOParams.salt)),
             abi.encodePacked(
                 type(ERC1967Proxy).creationCode,
                 abi.encode(createDAOParams.daoImplementation, "")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractal-framework/core-contracts",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractal-framework/core-contracts",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractal-framework/core-contracts",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "files": [
     "dist",
     "contracts"

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -7,7 +7,6 @@ import {
   IDAOFactory__factory,
   DAO__factory,
   ERC1967Proxy__factory,
-  IModuleFactoryBase__factory,
   IERC165__factory,
 } from "../typechain-types";
 import { expect } from "chai";

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -125,13 +125,18 @@ describe("DAOFactory", () => {
     const predictedAccess = ethers.utils.getCreate2Address(
       daoFactory.address,
       ethers.utils.solidityKeccak256(
-        ["address", "uint256", "bytes32"],
-        [deployer.address, chainId, ethers.utils.formatBytes32String("hi")]
+        ["address", "address", "uint256", "bytes32"],
+        [
+          deployer.address,
+          deployer.address,
+          chainId,
+          ethers.utils.formatBytes32String("hi"),
+        ]
       ),
       ethers.utils.solidityKeccak256(
         ["bytes", "bytes"],
-        // eslint-disable-next-line camelcase
         [
+          // eslint-disable-next-line camelcase
           ERC1967Proxy__factory.bytecode,
           abiCoder.encode(
             ["address", "bytes"],

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -105,13 +105,18 @@ describe("DAOFactory", () => {
     const predictedDAO = ethers.utils.getCreate2Address(
       daoFactory.address,
       ethers.utils.solidityKeccak256(
-        ["address", "uint256", "bytes32"],
-        [deployer.address, chainId, ethers.utils.formatBytes32String("hi")]
+        ["address", "address", "uint256", "bytes32"],
+        [
+          deployer.address,
+          deployer.address,
+          chainId,
+          ethers.utils.formatBytes32String("hi"),
+        ]
       ),
       ethers.utils.solidityKeccak256(
         ["bytes", "bytes"],
-        // eslint-disable-next-line camelcase
         [
+          // eslint-disable-next-line camelcase
           ERC1967Proxy__factory.bytecode,
           abiCoder.encode(["address", "bytes"], [daoImpl.address, []]),
         ]


### PR DESCRIPTION
This PR:
 - Updates the salt used to create the DAO and AccessControl contracts to use creator and msg.sender instead of tx.origin
 - Updates the tests to support the new salt pattern
 - Removes unnecessary supportsInterface functions since ERC165Storage is being used
 - Updates the npm package version from 0.1.4 to 0.1.5